### PR TITLE
Deploy to GitHub Pages on every run

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,6 +58,5 @@ jobs:
         with:
           path: deploy
       - name: Deploy to GitHub Pages
-        if: startsWith(github.ref, 'refs/tags/v')
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
Drops the tag-only gate so the manuscript draft publishes on every master push and PR build.